### PR TITLE
Fix Clear Tags button that was broken since the v5.19 refactor:

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const WORK_CONTAINER = "section ul"; // 仅包含作品
 const PAGE_BODY = '#__next [data-overlay-container="true"] > div:first-child'; // 自主页、收藏起下方
 const EDIT_BUTTON_CONTAINER = "section > div:first-child"; // 管理收藏按钮父容器，包含左侧作品文字
 const REMOVE_BOOKMARK_CONTAINER =
-  "section > div:nth-child(3) > div > div:first-child";
+  "section > div:nth-child(2) > div > div:first-child";
 const WORK_NUM = "section h2 + div";
 const ADD_TAGS_MODAL_ENTRY = 'ul[role="listbox"] button, ul li button'; // 原生添加标签窗口中标签按钮
 const ALL_TAGS_BUTTON =
@@ -3246,7 +3246,7 @@ async function injectElements() {
         return (
           section &&
           section.children.length >= 3 &&
-          section.children[2].querySelector('[role="button"]')
+          section.children[2].querySelector('input[type="checkbox"]')
         );
       };
 
@@ -3255,6 +3255,7 @@ async function injectElements() {
         const inEditMode = isInEditMode();
 
         if (inEditMode) {
+          if (DEBUG) console.log("[Label Bookmarks] In Edit Mode");
           // open edit mode
           let removeBookmarkContainer = document.querySelector(
             REMOVE_BOOKMARK_CONTAINER,

--- a/index.js
+++ b/index.js
@@ -2990,7 +2990,7 @@ async function updateWorkInfo(bookmarkTags) {
   const el = await waitForDom(WORK_SECTION);
   let workInfo = {};
   for (let i = 0; i < 100; i++) {
-    workInfo = Object.values(el)[0]["memoizedProps"]["children"][2]["props"];
+    workInfo = Object.values(el)[0]["memoizedProps"]["children"][3]["props"];
     if (Object.keys(workInfo).length) break;
     else await delay(200);
   }
@@ -3014,6 +3014,7 @@ async function initializeVariables() {
       token = await fetchTokenPolyfill();
       pageInfo.userId = window.location.href.match(/users\/(\d+)/)?.[1];
       pageInfo.client = { userId: uid, lang, token };
+      if (DEBUG) console.log("[Label Bookmarks] Page Info", pageInfo);
     } catch (err) {
       console.log(err);
       console.log("[Label Bookmarks] Initializing Failed");

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ let unsafeWindow_ = unsafeWindow,
 // selectors
 const BANNER = ".bg-surface1 > div:first-child";
 const THEME_CONTAINER = "html";
-const WORK_SECTION = "section:has(h2)"; // 作品section，从works->pagination
+const WORK_SECTION = "section"; // 作品section，从works->pagination
 const WORK_CONTAINER = "section ul"; // 仅包含作品
 const PAGE_BODY = '#__next [data-overlay-container="true"] > div:first-child'; // 自主页、收藏起下方
 const EDIT_BUTTON_CONTAINER = "section > div:first-child"; // 管理收藏按钮父容器，包含左侧作品文字

--- a/index.js
+++ b/index.js
@@ -603,20 +603,25 @@ async function clearBookmarkTags(works) {
 async function handleClearBookmarkTags(evt) {
   evt.preventDefault();
   const selected = [
-    ...document.querySelectorAll("label>div[aria-disabled='true']"),
+    ...document.querySelectorAll("input.sc-1838c2ca-4:checked"),
   ];
   if (!selected.length) return;
-
   const works = selected
     .map((el) => {
-      const middleChild = Object.values(
+      const fiber = Object.values(
         el.parentNode.parentNode.parentNode.parentNode,
-      )[0]["child"];
-      const work = middleChild["memoizedProps"]["work"];
-      work.associatedTags =
-        middleChild["child"]["memoizedProps"]["associatedTags"] || [];
-      work.bookmarkId = middleChild["memoizedProps"]["bookmarkId"];
-      return work;
+      )[0];
+      let node = fiber;
+      for (let i = 0; i < 15; i++) {
+        node = node.return;
+        if (node?.memoizedProps?.work) break;
+      }
+      const work = node.memoizedProps.work;
+        work.associatedTags = node.memoizedProps.work.associatedTags?.length
+          ? node.memoizedProps.work.associatedTags
+          : (node.memoizedProps.tagList || []);
+        work.bookmarkId = node.memoizedProps.bookmarkId;
+        return work;
     })
     .filter((work) => work.associatedTags.length);
   await clearBookmarkTags(works);
@@ -3061,17 +3066,11 @@ async function initializeVariables() {
     const clearTag = theme ? "jbzOgz" : "dydUg";
     const clearTagsButton = document.querySelector("#clear_tags_button");
     if (clearTagsButton) {
-      const clearButtonBgColor = theme
-        ? "rgba(255, 255, 255, 0.08)"
-        : "rgba(0, 0, 0, 0.04)";
-      const clearButtonTextColor = theme
-        ? "rgba(255, 255, 255, 0.88)"
-        : "rgba(0, 0, 0, 0.88)";
-      clearTagsButton.querySelector("div").style.backgroundColor =
-        clearButtonBgColor;
-      clearTagsButton.querySelector("div > div").style.color =
-        clearButtonTextColor;
-    }
+       const themeClass = theme ? "iKbYpV" : "huvZzJ";
+       const prevThemeClass = theme ? "huvZzJ" : "iKbYpV";
+       clearTagsButton.querySelector(".sc-294b2a21-0")
+           ?.classList.replace(prevThemeClass, themeClass);
+      }
   }).observe(themeDiv, { attributes: true });
 
   synonymDict = getValue("synonymDict", {});


### PR DESCRIPTION
- Fix button not appearing in edit mode (missing DOM injection)
- Update Pixiv CSS-in-JS class names (sc-294b2a21-0, huvZzJ/iKbYpV)
- Fix checkbox selector (label>div[aria-disabled] → input:checked)
- Replace hardcoded React fiber traversal with dynamic loop
- Fix theme observer using outdated class names